### PR TITLE
docs: Remove broken Transports section link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A flexible, transport-based logging system for JavaScript/TypeScript application
 
 ## Features
 
-- Multiple transport support (see [Transports](#transports));
+- Multiple transport support;
 - Log level filtering;
 - Context binding through forked loggers;
 - Data redaction capabilities;


### PR DESCRIPTION
The Transports section was removed in commit 563e433a9d0f6e011835ce555b3d382bc1f431c5, but the reference to it in the Features section was left behind. This change removes the broken link reference to avoid confusion.
