### PR TITLE
feat(transports): add PostgreSQLTransport

### DIFF
--- a/packages/transport-postgresql/README.md
+++ b/packages/transport-postgresql/README.md
@@ -1,0 +1,52 @@
+# `@caravan-logger/transport-postgresql`
+
+![NPM Last Update](https://img.shields.io/npm/v/@caravan-logger/transport-postgresql) ![NPM Last Update](https://img.shields.io/npm/last-update/@caravan-logger/transport-postgresql) ![NPM Last Update](https://img.shields.io/npm/l/@caravan-logger/transport-postgresql)
+
+A transport for logging to PostgreSQL.
+
+```txt
+ log_id | level |     message     | hostname  | process_id |            time            |        data
+--------+-------+-----------------+-----------+------------+----------------------------+--------------------
+      1 | INFO  | Info message    | wardstone |      18293 | 2025-07-03 18:55:54.045+00 | {"tech":"caravan"}
+      2 | ERROR | Error message   | wardstone |      18293 | 2025-07-03 18:55:54.046+00 | {"tech":"caravan"}
+      3 | WARN  | Warning message | wardstone |      18293 | 2025-07-03 18:55:54.046+00 | {"tech":"caravan"}
+      4 | FATAL | Fatal message   | wardstone |      18293 | 2025-07-03 18:55:54.047+00 | {"tech":"caravan"}
+(4 rows)
+```
+
+## Installation
+
+```bash
+pnpm add @caravan-logger/transport-postgresql
+```
+
+## Usage
+
+```typescript
+import { Logger } from "@caravan-logger/logger";
+import { PostgreSQLTransport } from "@caravan-logger/transport-postgresql";
+
+const postgreSQLTransport = new PostgreSQLTransport({
+  level: "INFO",
+  options: {
+    pool: new Pool({
+      host: "localhost",
+      port: 5432,
+      user: "caravan",
+      password: "***",
+      database: "caravan",
+    }),
+    table: "logs", // Can be ommited, default value is `logs`
+  },
+});
+
+// Make sure table exists before attempting to insert logs
+await postgreSQLTransport.init();
+
+const logger = new Logger({
+  level: "INFO",
+  transports: [
+    postgreSQLTransport,
+  ],
+});
+```

--- a/packages/transport-postgresql/package.json
+++ b/packages/transport-postgresql/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@caravan-logger/transport-postgresql",
+  "version": "0.4.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "description": "",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "prepublishOnly": "pnpm run build",
+    "clear": "rimraf dist/*",
+    "build": "pnpm run clear && tsup",
+    "build:types": "tsc --project tsconfig.json --emitDeclarationOnly --declaration"
+  },
+  "devDependencies": {
+    "@caravan-logger/logger": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.15.4",
+    "@types/pg-format": "^1.0.5",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.7.2"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "pg": "^8.16.3",
+    "pg-format": "^1.0.4"
+  }
+}

--- a/packages/transport-postgresql/src/error.ts
+++ b/packages/transport-postgresql/src/error.ts
@@ -1,0 +1,51 @@
+import { LoggerError } from "@caravan-logger/logger";
+
+type TCouldNotCreateTableErrorContext = {
+  readonly table: string | undefined;
+  readonly error?: string;
+};
+
+class CouldNotCreateTableError
+  extends LoggerError<TCouldNotCreateTableErrorContext> {
+  constructor({ table, error }: TCouldNotCreateTableErrorContext) {
+    super({
+      message: `Could not create table.`,
+      context: { table, error },
+    });
+  }
+}
+
+type TCouldNotInsertIntoTableErrorContext = {
+  readonly table: string | undefined;
+  readonly error?: string;
+};
+
+class CouldNotInsertIntoTableError
+  extends LoggerError<TCouldNotInsertIntoTableErrorContext> {
+  constructor({ table, error }: TCouldNotInsertIntoTableErrorContext) {
+    super({
+      message: `Could not insert into table.`,
+      context: { table, error },
+    });
+  }
+}
+
+type TFailedToClosePoolErrorContext = {
+  readonly error?: string;
+};
+
+class FailedToClosePoolError
+  extends LoggerError<TFailedToClosePoolErrorContext> {
+  constructor({ error }: TFailedToClosePoolErrorContext) {
+    super({
+      message: `Failed to close pool.`,
+      context: { error },
+    });
+  }
+}
+
+export {
+  CouldNotCreateTableError,
+  CouldNotInsertIntoTableError,
+  FailedToClosePoolError,
+};

--- a/packages/transport-postgresql/src/index.ts
+++ b/packages/transport-postgresql/src/index.ts
@@ -1,0 +1,101 @@
+import {
+  type TLogEntry,
+  Transport,
+  type TTransportBaseConstructorOptions,
+} from "@caravan-logger/logger";
+import { Pool, QueryConfig } from "pg";
+import format from "pg-format";
+import {
+  CouldNotCreateTableError,
+  CouldNotInsertIntoTableError,
+  FailedToClosePoolError,
+} from "./error";
+import {
+  CREATE_TABLE,
+  DEFAULT_TABLE,
+  INSERT_INTO,
+  TABLE_EXISTS,
+} from "./table";
+
+type TTableTransportOptions = {
+  pool: Pool;
+  table?: string | undefined;
+};
+
+class PostgreSQLTransport extends Transport<TTableTransportOptions> {
+  private readonly pool: Pool;
+  private readonly table: string;
+
+  constructor(
+    options: TTransportBaseConstructorOptions<TTableTransportOptions>,
+  ) {
+    super(options);
+
+    this.pool = options.options.pool;
+    this.table = options.options.table || DEFAULT_TABLE;
+  }
+
+  /**
+   * Check if requested table exists. If table is missing, create it.
+   */
+  async init(): Promise<void> {
+    try {
+      const data = await this.pool.query<{ exists: boolean }>(
+        format(TABLE_EXISTS, this.table),
+      );
+      const tableExists = data.rows[0]?.exists ?? false;
+      if (!tableExists) {
+        await this.pool.query(format(CREATE_TABLE, this.table));
+      }
+    } catch (error) {
+      throw new CouldNotCreateTableError({
+        table: this.pool.options.database,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async handle({
+    level,
+    message,
+    hostname,
+    processId,
+    time,
+    data,
+  }: TLogEntry): Promise<void> {
+    try {
+      const query = {
+        text: format(INSERT_INTO, this.table),
+        values: [
+          level,
+          message,
+          hostname,
+          processId,
+          time instanceof Date ? time : new Date(time),
+          JSON.stringify(data),
+        ],
+      } satisfies QueryConfig;
+      await this.pool.query(query);
+    } catch (error) {
+      throw new CouldNotInsertIntoTableError({
+        table: this.table,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Close current pool connection.
+   */
+  async close(): Promise<void> {
+    try {
+      await this.pool.end();
+    } catch (error) {
+      throw new FailedToClosePoolError({
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+export { PostgreSQLTransport };

--- a/packages/transport-postgresql/src/table.ts
+++ b/packages/transport-postgresql/src/table.ts
@@ -1,0 +1,27 @@
+const DEFAULT_TABLE = "logs";
+
+const TABLE_EXISTS = `
+  SELECT EXISTS (
+    SELECT FROM information_schema.tables 
+    WHERE table_name = %L
+  )
+`;
+
+const CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS %I (
+    log_id SERIAL PRIMARY KEY,
+    level VARCHAR(5) NOT NULL,
+    message TEXT NOT NULL,
+    hostname TEXT NOT NULL,
+    process_id INT NOT NULL,
+    time TIMESTAMPTZ NOT NULL,
+    data JSON NULL
+  )
+`;
+
+const INSERT_INTO = `
+  INSERT INTO %I (level, message, hostname, process_id, time, data)
+  VALUES ($1, $2, $3, $4, $5, $6)
+`;
+
+export { CREATE_TABLE, DEFAULT_TABLE, INSERT_INTO, TABLE_EXISTS };

--- a/packages/transport-postgresql/tsconfig.json
+++ b/packages/transport-postgresql/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "outDir": "dist"
+  }
+}

--- a/packages/transport-postgresql/tsup.config.mjs
+++ b/packages/transport-postgresql/tsup.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  format: ["esm", "cjs"],
+  onSuccess: "pnpm run build:types",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,37 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
 
+  packages/transport-postgresql:
+    dependencies:
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+      pg-format:
+        specifier: ^1.0.4
+        version: 1.0.4
+    devDependencies:
+      '@caravan-logger/logger':
+        specifier: workspace:*
+        version: link:../logger
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.10.2
+      '@types/pg':
+        specifier: ^8.15.4
+        version: 8.15.4
+      '@types/pg-format':
+        specifier: ^1.0.5
+        version: 1.0.5
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.2
+
   packages/typescript-config: {}
 
 packages:
@@ -707,6 +738,12 @@ packages:
 
   '@types/pako@1.0.7':
     resolution: {integrity: sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==}
+
+  '@types/pg-format@1.0.5':
+    resolution: {integrity: sha512-i+oEEJEC+1I3XAhgqtVp45Faj8MBbV0Aoq4rHsHD7avgLjyDkaWKObd514g0Q/DOUkdxU0P4CQ0iq2KR4SoJcw==}
+
+  '@types/pg@8.15.4':
+    resolution: {integrity: sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==}
 
   '@typescript-eslint/eslint-plugin@8.15.0':
     resolution: {integrity: sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==}
@@ -1566,6 +1603,44 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-format@1.0.4:
+    resolution: {integrity: sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==}
+    engines: {node: '>=4.0'}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1602,6 +1677,22 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1714,6 +1805,10 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1946,6 +2041,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2368,6 +2467,14 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/pako@1.0.7': {}
+
+  '@types/pg-format@1.0.5': {}
+
+  '@types/pg@8.15.4':
+    dependencies:
+      '@types/node': 22.10.2
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
 
   '@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0)(typescript@5.5.4))(eslint@9.15.0)(typescript@5.5.4)':
     dependencies:
@@ -3371,6 +3478,43 @@ snapshots:
       lru-cache: 11.0.2
       minipass: 7.1.2
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-format@1.0.4: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -3384,6 +3528,16 @@ snapshots:
   postcss-load-config@6.0.1:
     dependencies:
       lilconfig: 3.1.3
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -3534,6 +3688,8 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  split2@4.2.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3833,6 +3989,8 @@ snapshots:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
This PR adds PostgreSQL support through the `@caravan-logger/transport-postgresql` package.

The `PostgreSQLTransport` class includes two additional methods besides handle:
- `init` - validates the target table's existence, creating it if missing.
- `close` - terminates the pool connection in case the transport is no longer needed.

