### PR TITLE
feat(core): make `id` optional in `createLogger` when inheriting

### DIFF
--- a/.changeset/yellow-corners-wear.md
+++ b/.changeset/yellow-corners-wear.md
@@ -1,0 +1,10 @@
+---
+"@caravan-logger/logger": minor
+---
+
+feat(core): make `id` optional in `createLogger` when inheriting
+
+Adds an overload to createLogger so `id` can be omitted when
+`options.inherit.from` is provided, defaulting to the parent
+logger's id. Passing an explicit id still works and overrides
+the parent's id.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ transports and context, and can extend the context further without mutating
 the parent.
 
 ```ts
-const requestLogger = createLogger("request", {
+const requestLogger = createLogger({
   inherit: { from: logger },
   context: { requestId: "abc-123" },
 });

--- a/caravan/core/README.md
+++ b/caravan/core/README.md
@@ -43,10 +43,11 @@ be dispatched to its transports; records below it are dropped.
 Context passed to `createLogger` is merged into every record the logger
 writes. Child loggers created with `inherit` pick up the parent's level,
 transports, context and middleware, and can extend the context further
-without mutating the parent.
+without mutating the parent. `id` is optional when inheriting and defaults
+to the parent's `id`; pass one explicitly to give the child its own.
 
 ```ts
-const requestLogger = createLogger("request", {
+const requestLogger = createLogger({
   inherit: { from: logger },
   context: { requestId: "abc-123" },
 });

--- a/caravan/core/src/logger.ts
+++ b/caravan/core/src/logger.ts
@@ -123,8 +123,8 @@ const sendLogRecord = (
   }
 };
 
-/** Creates a logger, optionally inheriting level, transports, context and/or middleware from a parent. */
-export const createLogger = <
+/** Creates a logger with an explicit `id`, optionally inheriting level, transports, context and/or middleware from a parent. */
+export function createLogger<
   TParentLevel extends TDefaultLevels = typeof defaultLevel,
   TLevel extends TDefaultLevels = TParentLevel,
   TContext extends object = object,
@@ -133,8 +133,45 @@ export const createLogger = <
 >(
   id: string,
   options?: TCreateLoggerOptions<TParentLevel, TLevel, TContext, TInheritedContext, TKeepContext>,
-): TLogger<TLevel, TResolvedContext<TContext, TInheritedContext, TKeepContext>> => {
+): TLogger<TLevel, TResolvedContext<TContext, TInheritedContext, TKeepContext>>;
+/** Creates a logger that inherits from a parent, reusing the parent's `id`. */
+export function createLogger<
+  TParentLevel extends TDefaultLevels = typeof defaultLevel,
+  TLevel extends TDefaultLevels = TParentLevel,
+  TContext extends object = object,
+  TInheritedContext extends object = object,
+  TKeepContext extends boolean = true,
+>(
+  options: TCreateLoggerOptions<TParentLevel, TLevel, TContext, TInheritedContext, TKeepContext> & {
+    inherit: TInheritOptions<TParentLevel, TInheritedContext, TKeepContext>;
+  },
+): TLogger<TLevel, TResolvedContext<TContext, TInheritedContext, TKeepContext>>;
+export function createLogger<
+  TParentLevel extends TDefaultLevels = typeof defaultLevel,
+  TLevel extends TDefaultLevels = TParentLevel,
+  TContext extends object = object,
+  TInheritedContext extends object = object,
+  TKeepContext extends boolean = true,
+>(
+  idOrOptions:
+    | string
+    | (TCreateLoggerOptions<TParentLevel, TLevel, TContext, TInheritedContext, TKeepContext> & {
+        inherit: TInheritOptions<TParentLevel, TInheritedContext, TKeepContext>;
+      }),
+  maybeOptions?: TCreateLoggerOptions<
+    TParentLevel,
+    TLevel,
+    TContext,
+    TInheritedContext,
+    TKeepContext
+  >,
+): TLogger<TLevel, TResolvedContext<TContext, TInheritedContext, TKeepContext>> {
+  const options = typeof idOrOptions === "string" ? maybeOptions : idOrOptions;
   const parent = options?.inherit?.from;
+  const id = typeof idOrOptions === "string" ? idOrOptions : parent?.id;
+  if (id === undefined) {
+    throw new Error("createLogger requires an id unless inheriting from a parent logger");
+  }
   const keepTransports = options?.inherit?.transports ?? true;
   const keepContext = options?.inherit?.context ?? true;
   const keepMiddleware = options?.inherit?.middleware ?? true;
@@ -179,4 +216,4 @@ export const createLogger = <
     [TRANSPORTS_SYMBOL]: resolvedOptions.transports,
     [MIDDLEWARE_SYMBOL]: resolvedOptions.middleware,
   };
-};
+}

--- a/packages/benchmark/src/index.ts
+++ b/packages/benchmark/src/index.ts
@@ -14,7 +14,7 @@ const caravanLogger = createLogger("bench", {
   level: "INFO",
   transports: [createStreamTransport({ stream: fs.createWriteStream("/dev/null") })],
 });
-const caravanChild = createLogger("bench-child", {
+const caravanChild = createLogger({
   inherit: { from: caravanLogger },
   context: { module: "bench" },
 });


### PR DESCRIPTION
Adds an overload to createLogger so `id` can be omitted when `options.inherit.from` is provided, defaulting to the parent logger's `id`. Passing an explicit `id` still works and overrides the parent's `id`.
